### PR TITLE
AQLNames: check if player exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ target/
 
 # Linux temp files
 *~
+
+# gradle cache (might be a vscode extension which produce this)
+.gradle

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,3 @@ target/
 
 # Linux temp files
 *~
-
-# gradle cache (might be a vscode extension which produce this)
-.gradle

--- a/src/main/java/fr/aquilon/minecraft/aquilonthings/modules/AQLNames/AQLNames.java
+++ b/src/main/java/fr/aquilon/minecraft/aquilonthings/modules/AQLNames/AQLNames.java
@@ -175,6 +175,7 @@ public class AQLNames implements IModule {
 		Player target = (Player) targetEntity;
 		Player source = e.getPlayer();
 		PlayerInfo targetInfo = getPlayerInfo(target.getUniqueId());
+		if (targetInfo == null) return; // it can happens when the player model is used for an NPC
 		String description = ChatColor.WHITE+targetInfo.getName()+ChatColor.GRAY+": * "+ChatColor.ITALIC+
 				targetInfo.getDescription("Une personne comme une autre") +ChatColor.RESET+ChatColor.GRAY+" *";
 		source.sendMessage(ChatColor.translateAlternateColorCodes('&', description));

--- a/src/main/java/fr/aquilon/minecraft/aquilonthings/modules/AQLNames/AQLNames.java
+++ b/src/main/java/fr/aquilon/minecraft/aquilonthings/modules/AQLNames/AQLNames.java
@@ -175,7 +175,7 @@ public class AQLNames implements IModule {
 		Player target = (Player) targetEntity;
 		Player source = e.getPlayer();
 		PlayerInfo targetInfo = getPlayerInfo(target.getUniqueId());
-		if (targetInfo == null) return; // it can happens when the player model is used for an NPC
+		if (targetInfo == null) return; // it can happen when the player model is used for an NPC
 		String description = ChatColor.WHITE+targetInfo.getName()+ChatColor.GRAY+": * "+ChatColor.ITALIC+
 				targetInfo.getDescription("Une personne comme une autre") +ChatColor.RESET+ChatColor.GRAY+" *";
 		source.sendMessage(ChatColor.translateAlternateColorCodes('&', description));


### PR DESCRIPTION
Do not print information of a player if they cannot be retrieve.

It can happens when using a player model for something which is not a real player (in my case, Citizen plugin)